### PR TITLE
Adds versioning to Docker image builds

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -32,6 +32,8 @@ jobs:
           push: true
           platforms: linux/amd64,linux/arm64
           file: Dockerfile
+          build-args: |
+            VERSION=${{ github.sha }}
           tags: |
             ghcr.io/${{ github.repository_owner }}/${{ github.repository }}:latest
             ghcr.io/${{ github.repository_owner }}/${{ github.repository }}:${{ github.ref_name }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,39 +1,43 @@
-# Use the latest official Golang image to build the application
+# Use the official Go image as a base image
 FROM golang:1.25.3-alpine AS builder
 
-# Build arguments
+# Add build arguments
+ARG VERSION
 ARG TARGETOS
 ARG TARGETARCH
 
-# Set the Current Working Directory inside the container
+# Set the working directory inside the container
 WORKDIR /app
 
-# Copy go mod
-COPY go.mod ./
+# Copy go.mod and go.sum files to download dependencies
+COPY go.mod go.sum ./
 
-# Download all dependencies. Dependencies will be cached if the go.mod and go.sum files are not changed
+# Download dependencies
 RUN go mod download
 
-# Copy the source from the current directory to the Working Directory inside the container
+# Copy the rest of the application source code
 COPY . .
 
-# Build the Go app
-RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -o main .
+# Build the Go application, injecting the version
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -installsuffix cgo -ldflags "-X main.version=${VERSION}" -o main .
 
-# Start a new stage from scratch
+# Use a minimal base image for the final image
 FROM alpine:latest
 
-# Set the Current Working Directory inside the container
-WORKDIR /root/
+# Set the working directory inside the container
+WORKDIR /app
 
-# Copy the Pre-built binary file from the previous stage
+# Copy the built binary from the builder stage
 COPY --from=builder /app/main .
+
+# Copy the static folder
+COPY --from=builder /app/static ./static/
 
 # Copy the template file
 COPY --from=builder /app/template.html .
 
-# Copy the static file
-COPY --from=builder /app/static ./static
+# Copy the robots.txt file
+COPY --from=builder /app/robots.txt .
 
 # Expose port 8080 to the outside world
 EXPOSE 8080

--- a/main.go
+++ b/main.go
@@ -23,7 +23,7 @@ func main() {
 		return
 	}
 
-	version = strconv.FormatInt(time.Now().Unix(), 10)
+	
 
 	http.Handle("/", cspHandler(gzipHandler(http.HandlerFunc(weekHandler))))
 	http.Handle("/api/previous/", cspHandler(http.HandlerFunc(previousWeekHandler)))


### PR DESCRIPTION
Adds a build argument to the Dockerfile to include the git commit SHA as the version. This allows for better tracking and identification of specific builds.

The Dockerfile is updated to use build arguments for OS and architecture, and to inject the version during the build process.

The github workflow is updated to pass the github SHA as the VERSION build argument.