### PR TITLE
Add keyboard navigation for week switching

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -8,6 +8,16 @@ document.addEventListener('DOMContentLoaded', function() {
     document.getElementById('week').addEventListener('click', function() {
         resetToCurrentWeek();
     });
+
+    document.addEventListener('keydown', function(event) {
+        if (event.key === 'ArrowLeft') {
+            event.preventDefault();
+            updateWeek('previous');
+        } else if (event.key === 'ArrowRight') {
+            event.preventDefault();
+            updateWeek('next');
+        }
+    });
 });
 
 function updateWeek(direction) {


### PR DESCRIPTION
Implements issue #38 by adding keyboard event listeners to the document for ArrowLeft and ArrowRight keys.

---
*PR created automatically by Jules for task [5955436540980245251](https://jules.google.com/task/5955436540980245251) started by @mazk0*