### PR TITLE
Prevent text selection on week navigation buttons

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -9,6 +9,17 @@ document.addEventListener('DOMContentLoaded', function() {
         resetToCurrentWeek();
     });
 
+    // Prevent text selection on rapid clicks
+    document.getElementById('prevWeekButton').addEventListener('mousedown', function(e) {
+        e.preventDefault();
+    });
+    document.getElementById('nextWeekButton').addEventListener('mousedown', function(e) {
+        e.preventDefault();
+    });
+    document.getElementById('week').addEventListener('mousedown', function(e) {
+        e.preventDefault();
+    });
+
     document.addEventListener('keydown', function(event) {
         if (event.key === 'ArrowLeft') {
             event.preventDefault();

--- a/static/script.js
+++ b/static/script.js
@@ -9,7 +9,6 @@ document.addEventListener('DOMContentLoaded', function() {
         resetToCurrentWeek();
     });
 
-    // Prevent text selection on rapid clicks
     document.getElementById('prevWeekButton').addEventListener('mousedown', function(e) {
         e.preventDefault();
     });


### PR DESCRIPTION
Prevents text selection when rapidly clicking week navigation buttons.

---
*PR created automatically by Jules for task [15520886563752848244](https://jules.google.com/task/15520886563752848244) started by @mazk0*