### PR TITLE
Refactor codebase into internal packages

### DIFF
--- a/internal/middleware/cache_middleware.go
+++ b/internal/middleware/cache_middleware.go
@@ -1,8 +1,8 @@
-package main
+package middleware
 
 import "net/http"
 
-func cacheHandler(next http.Handler) http.Handler {
+func CacheHandler(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Set cache headers
 		w.Header().Set("Cache-Control", "public, max-age=31536000")

--- a/internal/middleware/csp_middleware.go
+++ b/internal/middleware/csp_middleware.go
@@ -1,8 +1,8 @@
-package main
+package middleware
 
 import "net/http"
 
-func cspHandler(next http.Handler) http.Handler {
+func CspHandler(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Set CSP headers
 		w.Header().Set("Content-Security-Policy", "default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data:;")

--- a/internal/middleware/gzip_middleware.go
+++ b/internal/middleware/gzip_middleware.go
@@ -1,4 +1,4 @@
-package main
+package middleware
 
 import (
 	"compress/gzip"
@@ -14,8 +14,8 @@ var gzipPool = sync.Pool{
 	},
 }
 
-// gzipHandler wraps an http.Handler to compress responses with gzip
-func gzipHandler(next http.Handler) http.Handler {
+// GzipHandler wraps an http.Handler to compress responses with gzip
+func GzipHandler(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Check if the client accepts gzip encoding
 		if !strings.Contains(r.Header.Get("Accept-Encoding"), "gzip") {

--- a/internal/middleware/gzip_middleware_test.go
+++ b/internal/middleware/gzip_middleware_test.go
@@ -1,4 +1,4 @@
-package main
+package middleware
 
 import (
 	"compress/gzip"
@@ -9,7 +9,7 @@ import (
 )
 
 func BenchmarkGzipMiddleware(b *testing.B) {
-	handler := gzipHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	handler := GzipHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Write enough data to make gzip actually do some work
 		data := make([]byte, 1024)
 		for i := range data {
@@ -30,7 +30,7 @@ func BenchmarkGzipMiddleware(b *testing.B) {
 }
 
 func TestGzipMiddlewareCorrectness(t *testing.T) {
-	handler := gzipHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	handler := GzipHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte("Hello World"))
 	}))
 

--- a/internal/week/week_info.go
+++ b/internal/week/week_info.go
@@ -1,4 +1,4 @@
-package main
+package week
 
 type WeekInfo struct {
 	Week      int

--- a/internal/week/week_utils.go
+++ b/internal/week/week_utils.go
@@ -1,8 +1,8 @@
-package main
+package week
 
 import "time"
 
-func getFirstAndLastDateOfWeek(year, week int) (time.Time, time.Time) {
+func GetFirstAndLastDateOfWeek(year, week int) (time.Time, time.Time) {
 	// January 4th is always in week 1 according to ISO 8601
 	referenceDate := time.Date(year, time.January, 4, 0, 0, 0, 0, time.UTC)
 
@@ -25,7 +25,7 @@ func getFirstAndLastDateOfWeek(year, week int) (time.Time, time.Time) {
 	return firstDateOfWeek, lastDateOfWeek
 }
 
-func getNumberOfWeeks(year int) int {
+func GetNumberOfWeeks(year int) int {
 	// December 28th is always in the last week according to ISO 8601
 	endDate := time.Date(year, time.December, 28, 0, 0, 0, 0, time.UTC)
 	_, lastWeek := endDate.ISOWeek()
@@ -33,7 +33,7 @@ func getNumberOfWeeks(year int) int {
 	return lastWeek
 }
 
-func timeFromYearAndWeek(year, week int) time.Time {
+func TimeFromYearAndWeek(year, week int) time.Time {
 	// January 4th is always in the first week of the year
 	jan4 := time.Date(year, time.January, 4, 0, 0, 0, 0, time.UTC)
 	// Find the Monday of the first week of the year

--- a/main.go
+++ b/main.go
@@ -9,6 +9,9 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"CurrentWeek/internal/middleware"
+	"CurrentWeek/internal/week"
 )
 
 var tmpl *template.Template
@@ -25,11 +28,11 @@ func main() {
 
 	
 
-	http.Handle("/", cspHandler(gzipHandler(http.HandlerFunc(weekHandler))))
-	http.Handle("/api/previous/", cspHandler(http.HandlerFunc(previousWeekHandler)))
-	http.Handle("/api/next/", cspHandler(http.HandlerFunc(nextWeekHandler)))
-	http.Handle("/api/week/current/", cspHandler(http.HandlerFunc(currentWeekUpdateHandler)))
-	http.Handle("/static/", http.StripPrefix("/static/", cacheHandler(gzipHandler(http.FileServer(http.Dir("./static"))))))
+	http.Handle("/", middleware.CspHandler(middleware.GzipHandler(http.HandlerFunc(weekHandler))))
+	http.Handle("/api/previous/", middleware.CspHandler(http.HandlerFunc(previousWeekHandler)))
+	http.Handle("/api/next/", middleware.CspHandler(http.HandlerFunc(nextWeekHandler)))
+	http.Handle("/api/week/current/", middleware.CspHandler(http.HandlerFunc(currentWeekUpdateHandler)))
+	http.Handle("/static/", http.StripPrefix("/static/", middleware.CacheHandler(middleware.GzipHandler(http.FileServer(http.Dir("./static"))))))
 	http.Handle("/robots.txt", http.FileServer(http.Dir(".")))
 
 	port := "8080"
@@ -45,16 +48,16 @@ func weekHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	year, week, err := parseWeekYearFromRequest(r)
+	year, weekNum, err := parseWeekYearFromRequest(r)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 
-	firstDateOfWeek, lastDateOfWeek := getFirstAndLastDateOfWeek(year, week)
+	firstDateOfWeek, lastDateOfWeek := week.GetFirstAndLastDateOfWeek(year, weekNum)
 
-	weekInfo := WeekInfoTemplate{
-		Week:       week,
+	weekInfo := week.WeekInfoTemplate{
+		Week:       weekNum,
 		FirstDate:  firstDateOfWeek.Format("2006-01-02"),
 		LastDate:   lastDateOfWeek.Format("2006-01-02"),
 		Version:    version,
@@ -84,16 +87,16 @@ func handleWeekRequest(w http.ResponseWriter, r *http.Request, operation func(ti
 		return
 	}
 
-	year, week, err := parseWeekYearFromRequest(r)
+	year, weekNum, err := parseWeekYearFromRequest(r)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 
-	current := timeFromYearAndWeek(year, week)
+	current := week.TimeFromYearAndWeek(year, weekNum)
 	current = operation(current)
-	year, week = current.ISOWeek()
-	sendWeekInfoResponse(w, year, week)
+	year, weekNum = current.ISOWeek()
+	sendWeekInfoResponse(w, year, weekNum)
 }
 
 func currentWeekUpdateHandler(w http.ResponseWriter, r *http.Request) {
@@ -103,12 +106,12 @@ func currentWeekUpdateHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	now := time.Now()
-	year, week := now.ISOWeek()
-	sendWeekInfoResponse(w, year, week)
+	year, weekNum := now.ISOWeek()
+	sendWeekInfoResponse(w, year, weekNum)
 }
 
-func sendWeekInfoResponse(w http.ResponseWriter, year int, week int) {
-	weekInfo := getWeekInfo(year, week)
+func sendWeekInfoResponse(w http.ResponseWriter, year int, weekNum int) {
+	weekInfo := getWeekInfo(year, weekNum)
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(weekInfo); err != nil {
 		http.Error(w, fmt.Sprintf("Failed to handle the request please try again later: %v", err), http.StatusInternalServerError)
@@ -117,7 +120,7 @@ func sendWeekInfoResponse(w http.ResponseWriter, year int, week int) {
 
 func parseWeekYearFromRequest(r *http.Request) (int, int, error) {
 	now := time.Now()
-	year, week := now.ISOWeek()
+	year, weekNum := now.ISOWeek()
 
 	pathParts := strings.Split(r.URL.Path, "/")
 	if len(pathParts) > 2 {
@@ -137,7 +140,7 @@ func parseWeekYearFromRequest(r *http.Request) (int, int, error) {
 			weekParam := pathParts[weekIndex+1]
 			if weekParam != "" {
 				if weekArgs, err := strconv.Atoi(weekParam); err == nil {
-					week = weekArgs
+					weekNum = weekArgs
 				} else {
 					return 0, 0, fmt.Errorf("Invalid week number: %s", weekParam)
 				}
@@ -145,13 +148,13 @@ func parseWeekYearFromRequest(r *http.Request) (int, int, error) {
 		}
 	}
 
-	return year, week, nil
+	return year, weekNum, nil
 }
 
-func getWeekInfo(year int, week int) WeekInfo {
-	firstDateOfWeek, lastDateOfWeek := getFirstAndLastDateOfWeek(year, week)
-	return WeekInfo{
-		Week:      week,
+func getWeekInfo(year int, weekNum int) week.WeekInfo {
+	firstDateOfWeek, lastDateOfWeek := week.GetFirstAndLastDateOfWeek(year, weekNum)
+	return week.WeekInfo{
+		Week:      weekNum,
 		FirstDate: firstDateOfWeek.Format("2006-01-02"),
 		LastDate:  lastDateOfWeek.Format("2006-01-02"),
 	}


### PR DESCRIPTION
Moved middleware and week logic to `internal` packages to improve project structure and facilitate better testing practices. Unit tests are now co-located with their respective code in `internal/middleware`, while e2e tests remain in `tests/e2e`. Verified all tests pass.

---
*PR created automatically by Jules for task [8626184606770066702](https://jules.google.com/task/8626184606770066702) started by @mazk0*