### PR TITLE
Update Go version to 1.26.0 and update dependencies

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.25.3'
+        go-version: '1.26.0'
 
     - name: Setup Node.js
       uses: actions/setup-node@v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use the official Go image as a base image
-FROM golang:1.25.3-alpine AS builder
+FROM golang:1.26.0-alpine AS builder
 
 # Add build arguments
 ARG VERSION

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module CurrentWeek
 
-go 1.25.3
+go 1.26.0

--- a/tests/e2e/package-lock.json
+++ b/tests/e2e/package-lock.json
@@ -8,8 +8,8 @@
       "name": "e2e-tests",
       "version": "1.0.0",
       "devDependencies": {
-        "@playwright/test": "^1.41.2",
-        "@types/node": "^20.11.19"
+        "@playwright/test": "^1.58.2",
+        "@types/node": "^25.3.0"
       }
     },
     "node_modules/@playwright/test": {
@@ -29,13 +29,13 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.19.33",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.33.tgz",
-      "integrity": "sha512-Rs1bVAIdBs5gbTIKza/tgpMuG1k3U/UMJLWecIMxNdJFDMzcM5LOiLVRYh3PilWEYDIeUDv7bpiHPLPsbydGcw==",
+      "version": "25.3.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.3.0.tgz",
+      "integrity": "sha512-4K3bqJpXpqfg2XKGK9bpDTc6xO/xoUP/RBWS7AtRMug6zZFaRekiLzjVtAoZMquxoAbzBvy5nxQ7veS5eYzf8A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~7.18.0"
       }
     },
     "node_modules/fsevents": {
@@ -86,9 +86,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "dev": true,
       "license": "MIT"
     }

--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -6,7 +6,7 @@
     "test": "playwright test"
   },
   "devDependencies": {
-    "@playwright/test": "^1.41.2",
-    "@types/node": "^20.11.19"
+    "@playwright/test": "^1.58.2",
+    "@types/node": "^25.3.0"
   }
 }


### PR DESCRIPTION
Updated Go version to 1.26.0 and updated npm dependencies in e2e tests.
Modified `go.mod`, `Dockerfile`, and `.github/workflows/e2e.yml` to reflect the new Go version.
Ran `go mod tidy` and `npm update` to ensure consistency.
Verified changes by running tests.

---
*PR created automatically by Jules for task [14320099084305400332](https://jules.google.com/task/14320099084305400332) started by @mazk0*