### PR TITLE
Add explicit permissions to e2e workflow

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main, master ]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     timeout-minutes: 60


### PR DESCRIPTION
Added `permissions: contents: read` to `.github/workflows/e2e.yml` to resolve a GitHub Actions security warning. Verified that the `docker-image.yml` workflow already has appropriate permissions. Ran local e2e tests to ensure the environment is healthy.

---
*PR created automatically by Jules for task [5963385358602332532](https://jules.google.com/task/5963385358602332532) started by @mazk0*