### PR TITLE
Add main landmark to HTML template

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -10,6 +10,13 @@ body {
     color: white;
 }
 
+main {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+}
+
 h1 {
     text-align: center;
 }

--- a/template.html
+++ b/template.html
@@ -14,16 +14,18 @@
     <script src="/static/script.js?v={{.Version}}" defer></script>
 </head>
 <body>
-    <div class="week-container">
-        <button id="prevWeekButton" class="nav-button" aria-label="Previous week">&#x276E;</button>
-        <button id="week" class="week-button" aria-label="Current week">{{.Week}}</button>
-        <button id="nextWeekButton" class="nav-button" aria-label="Next week">&#x276F;</button>
-    </div>
-    <p id="dateRange" class="date-range">
-        <span id="firstDate" class="date">{{.FirstDate}}</span>
-        <span class="dash"> - </span>
-        <span id="lastDate" class="date">{{.LastDate}}</span>
-    </p>
+    <main>
+        <div class="week-container">
+            <button id="prevWeekButton" class="nav-button" aria-label="Previous week">&#x276E;</button>
+            <button id="week" class="week-button" aria-label="Current week">{{.Week}}</button>
+            <button id="nextWeekButton" class="nav-button" aria-label="Next week">&#x276F;</button>
+        </div>
+        <p id="dateRange" class="date-range">
+            <span id="firstDate" class="date">{{.FirstDate}}</span>
+            <span class="dash"> - </span>
+            <span id="lastDate" class="date">{{.LastDate}}</span>
+        </p>
+    </main>
     <footer>
         <a href="{{.GitHubRepo}}" target="_blank" class="github-link">View on GitHub</a>
     </footer>


### PR DESCRIPTION
This change wraps the main content of the page (week navigation and date range) in a <main> tag to improve accessibility and satisfy Lighthouse audit requirements. It also updates the CSS to ensure the layout remains centered and consistent with the previous design.

---
*PR created automatically by Jules for task [4367633918559370254](https://jules.google.com/task/4367633918559370254) started by @mazk0*