### PR TITLE
Remove forgotten console.log

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -38,7 +38,6 @@ function updateWeek(direction) {
     const lastDateYear = lastDateText.split('-')[0];
 
     const currentYear = parseInt(currentWeek) > 50 && (parseInt(firstDateYear) < parseInt(lastDateYear)) ? firstDateYear : lastDateYear;
-    console.log(currentYear);
     let url = '';
     if (direction === 'previous') {
         url = `/api/previous/year/${currentYear}/week/${currentWeek}`;


### PR DESCRIPTION
Removed a `console.log(currentYear)` statement from `static/script.js` that was accidentally left in the codebase.

---
*PR created automatically by Jules for task [1500897947406744114](https://jules.google.com/task/1500897947406744114) started by @mazk0*