### PR TITLE
feat: reset to current week on ArrowUp keydown

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -26,6 +26,9 @@ document.addEventListener('DOMContentLoaded', function() {
         } else if (event.key === 'ArrowRight') {
             event.preventDefault();
             updateWeek('next');
+        } else if (event.key === 'ArrowUp') {
+            event.preventDefault();
+            resetToCurrentWeek();
         }
     });
 });

--- a/tests/e2e/tests/app.spec.ts
+++ b/tests/e2e/tests/app.spec.ts
@@ -48,4 +48,19 @@ test.describe('Current Week App', () => {
     // Verify it's back to initial
     await expect(weekElement).toHaveText(initialWeekText);
   });
+
+  test('resets to current week on ArrowUp', async ({ page }) => {
+    const weekElement = page.locator('#week');
+    const initialWeekText = await weekElement.innerText();
+
+    // Navigate away first
+    await page.locator('#nextWeekButton').click();
+    await expect(weekElement).not.toHaveText(initialWeekText);
+
+    // Press ArrowUp to reset
+    await page.keyboard.press('ArrowUp');
+
+    // Verify it's back to initial
+    await expect(weekElement).toHaveText(initialWeekText);
+  });
 });


### PR DESCRIPTION
Adds keyboard navigation support for resetting the view to the current week using the `ArrowUp` key. This enhances the user experience by allowing them to quickly return to the current week, similar to the existing `ArrowLeft` and `ArrowRight` navigation for previous and next weeks. I also added a test for the new behavior.

---
*PR created automatically by Jules for task [2858838503754281752](https://jules.google.com/task/2858838503754281752) started by @mazk0*